### PR TITLE
Use ConstantNode instead of NotTracked

### DIFF
--- a/src/back.jl
+++ b/src/back.jl
@@ -72,7 +72,7 @@ function back(x::_Tracker, Δ, once)
 end
 
 back(x::TrackedTypes, Δ, once) = back(tracker(x), Δ, once)
-back(::NotTracked, Δ, once) = return
+back(::ConstNode, Δ, once) = return
 
 # Interface methods
 

--- a/src/back.jl
+++ b/src/back.jl
@@ -72,7 +72,7 @@ function back(x::_Tracker, Δ, once)
 end
 
 back(x::TrackedTypes, Δ, once) = back(tracker(x), Δ, once)
-back(::ConstNode, Δ, once) = return
+back(::ConstantNode, Δ, once) = return
 
 # Interface methods
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -256,7 +256,7 @@ x::TrackedVector  * y::TrackedVector  = track(*, x, y)
 # x::TrackedReal * y::TrackedArray = track(*, x, y)
 
 # Ambiguity fixes
-# TODO: handle ConstNode here
+# TODO: handle ConstantNode here
 Base.:*(x::TrackedMatrix,y::Transpose{T,<:AbstractVector{T}}) where {T} = track(*, x, CN(y))
 Base.:*(x::TrackedMatrix,y::Transpose{T,<:AbstractMatrix{T}}) where {T} = track(*, x, CN(y))
 Base.:*(x::TrackedVector,y::Transpose{T,<:AbstractVector{T}}) where {T} = track(*, x, CN(y))

--- a/src/tracked_types.jl
+++ b/src/tracked_types.jl
@@ -64,16 +64,16 @@ end
 Constant Node in the graph.
 we can have y = 2*x; x is TrackedArray, and we also want to keep 2 into a type for a nice display of the graph and for debugging purposes.
 """
-struct ConstNode{T}
+struct ConstantNode{T}
   data::T
 end
 
-data(x::ConstNode) = x.data
+data(x::ConstantNode) = x.data
 
-CN(data::T) where T = ConstNode{T}(data) # convenient outer ctor; short name as it is used a lot in the capturing methods
+CN(data::T) where T = ConstantNode{T}(data) # convenient outer ctor; short name as it is used a lot in the capturing methods
 
 TrackedTypes = Union{TrackedReal, TrackedArray, TrackedTuple}
-Parent = Union{TrackedReal, TrackedArray, TrackedTuple, ConstNode}
+Parent = Union{TrackedReal, TrackedArray, TrackedTuple, ConstantNode}
 Parents = Tuple{Vararg{Parent}}
 
 istracked(x::_Tracker) = true

--- a/src/tracked_types.jl
+++ b/src/tracked_types.jl
@@ -60,17 +60,20 @@ struct TrackedTuple{T<:Tuple}
   tracker::_Tracker
 end
 
-# we can have y = 2*x; x is TrackedArray, and we also want to keep 2 into a type for a nice display of the graph and for debugging purposes.
-struct NotTracked{T}
+"""
+Constant Node in the graph.
+we can have y = 2*x; x is TrackedArray, and we also want to keep 2 into a type for a nice display of the graph and for debugging purposes.
+"""
+struct ConstNode{T}
   data::T
 end
 
-data(x::NotTracked) = x.data
+data(x::ConstNode) = x.data
 
-NT = NotTracked # convenient alias
+CN(data::T) where T = ConstNode{T}(data) # convenient outer ctor; short name as it is used a lot in the capturing methods
 
 TrackedTypes = Union{TrackedReal, TrackedArray, TrackedTuple}
-Parent = Union{TrackedReal, TrackedArray, TrackedTuple, NotTracked}
+Parent = Union{TrackedReal, TrackedArray, TrackedTuple, ConstNode}
 Parents = Tuple{Vararg{Parent}}
 
 istracked(x::_Tracker) = true


### PR DESCRIPTION
The name NotTracked is a bit problematic as it contains "Not". "Not" something can have a name. 

What we mean with NotTracked actually? Consider `2*tracked_array` or `rand(3,2) * tracked_array`. `2` and val of `rand(3,2)` are actually nodes in the graph which are constant: they do not change in the forward pass, nor in the backward pass. So I think `ConstantNode` is more descriptive name. Its also an internal type, the end user shall not deal with it. 