### PR TITLE
Print graph with thew new types

### DIFF
--- a/src/Tracker.jl
+++ b/src/Tracker.jl
@@ -113,39 +113,6 @@ function track(f::F, xs...; kw...) where F
   make_tracked(y, back, xs)
 end
 
-function print_graph(io::IO, x::ConstantNode, indent, indent_all)
-  println(io, indent_all*"ConstantNode=", x)
-end
-
-"Function to print the graph of an Tracked"
-function print_graph(io::IO, x::_Tracker, indent, indent_all)
-  println(io, indent_all*"Tracker=")
-  indent_all *= indent
-  println(io, indent_all*"pullback=", x.pullback)
-  grad = isdefined(x, :grad) ? x.grad : undef
-  println(io, indent_all*"grad=", grad)
-  # print_graph_(io, x.f, indent, indent_all)
-  if isempty(x.parents)
-    println(io, indent_all*"Parents=()")
-    return
-  end
-  
-  println(io, indent_all*"Parents=")
-  indent_all *= indent
-  for p in x.parents    
-    print_graph(io::IO, p, indent, indent_all)
-  end
-end
-
-"Function to print the graph of an TrackedArray, TrackedReal, TrackedTuple}"
-function print_graph(io::IO, x::TrackedTypes, indent="-", indent_all="")
-  println(io, indent_all*"TrackedType")
-  indent_all *= indent
-  println(io, indent_all*"data=", data(x))  
-  print_graph(io, tracker(x), indent, indent_all)
-end
-
-print_graph(io::IO, x::TrackedTypes; indent="-") = print_graph(io, x, indent, "")
 
 """
     hook(f, x) -> x′

--- a/src/back.jl
+++ b/src/back.jl
@@ -72,7 +72,7 @@ function back(x::_Tracker, Δ, once)
 end
 
 back(x::TrackedTypes, Δ, once) = back(tracker(x), Δ, once)
-back(::NotTracked, Δ, once) = return
+back(::ConstNode, Δ, once) = return
 
 # Interface methods
 

--- a/src/back.jl
+++ b/src/back.jl
@@ -72,7 +72,7 @@ function back(x::_Tracker, Δ, once)
 end
 
 back(x::TrackedTypes, Δ, once) = back(tracker(x), Δ, once)
-back(::ConstNode, Δ, once) = return
+back(::ConstantNode, Δ, once) = return
 
 # Interface methods
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -256,7 +256,7 @@ x::TrackedVector  * y::TrackedVector  = track(*, x, y)
 # x::TrackedReal * y::TrackedArray = track(*, x, y)
 
 # Ambiguity fixes
-# TODO: handle ConstNode here
+# TODO: handle ConstantNode here
 Base.:*(x::TrackedMatrix,y::Transpose{T,<:AbstractVector{T}}) where {T} = track(*, x, CN(y))
 Base.:*(x::TrackedMatrix,y::Transpose{T,<:AbstractMatrix{T}}) where {T} = track(*, x, CN(y))
 Base.:*(x::TrackedVector,y::Transpose{T,<:AbstractVector{T}}) where {T} = track(*, x, CN(y))

--- a/src/tracked_types.jl
+++ b/src/tracked_types.jl
@@ -64,16 +64,16 @@ end
 Constant Node in the graph.
 we can have y = 2*x; x is TrackedArray, and we also want to keep 2 into a type for a nice display of the graph and for debugging purposes.
 """
-struct ConstNode{T}
+struct ConstantNode{T}
   data::T
 end
 
-data(x::ConstNode) = x.data
+data(x::ConstantNode) = x.data
 
-CN(data::T) where T = ConstNode{T}(data) # convenient outer ctor; short name as it is used a lot in the capturing methods
+CN(data::T) where T = ConstantNode{T}(data) # convenient outer ctor; short name as it is used a lot in the capturing methods
 
 TrackedTypes = Union{TrackedReal, TrackedArray, TrackedTuple}
-Parent = Union{TrackedReal, TrackedArray, TrackedTuple, ConstNode}
+Parent = Union{TrackedReal, TrackedArray, TrackedTuple, ConstantNode}
 Parents = Tuple{Vararg{Parent}}
 
 istracked(x::_Tracker) = true

--- a/src/tracked_types.jl
+++ b/src/tracked_types.jl
@@ -60,17 +60,20 @@ struct TrackedTuple{T<:Tuple}
   tracker::_Tracker
 end
 
-# we can have y = 2*x; x is TrackedArray, and we also want to keep 2 into a type for a nice display of the graph and for debugging purposes.
-struct NotTracked{T}
+"""
+Constant Node in the graph.
+we can have y = 2*x; x is TrackedArray, and we also want to keep 2 into a type for a nice display of the graph and for debugging purposes.
+"""
+struct ConstNode{T}
   data::T
 end
 
-data(x::NotTracked) = x.data
+data(x::ConstNode) = x.data
 
-NT = NotTracked # convenient alias
+CN(data::T) where T = ConstNode{T}(data) # convenient outer ctor; short name as it is used a lot in the capturing methods
 
 TrackedTypes = Union{TrackedReal, TrackedArray, TrackedTuple}
-Parent = Union{TrackedReal, TrackedArray, TrackedTuple, NotTracked}
+Parent = Union{TrackedReal, TrackedArray, TrackedTuple, ConstNode}
 Parents = Tuple{Vararg{Parent}}
 
 istracked(x::_Tracker) = true

--- a/test/broadcast_play.jl
+++ b/test/broadcast_play.jl
@@ -1,4 +1,4 @@
-using Tracker: Tracker, param, TrackedArray, TrackedReal, TrackedTypes, track, back!
+using Tracker: Tracker, param, TrackedArray, TrackedReal, TrackedTypes, track, back!, print_graph
 using LinearAlgebra: diagm, dot, LowerTriangular, norm, det, logdet, logabsdet, I, Diagonal
 using ChainRules: ChainRules, rrule, NoTangent
 
@@ -14,6 +14,9 @@ ta.tracker.grad
 ##
 ta = param([1, 2, 3])
 tb = ta .+ 1
+
+print_graph(stdout, tb)
+
 ##
 ta = param([1, 2, 3])
 tb = ta.^2


### PR DESCRIPTION
Updated the print_graph I use for debugging. The display can be improved.
See how the pullback is stored: `pullback=#111`. We shall store and display the original function instead (as is or as string) for an intuitive display.

```julia
julia> ta = param([1, 2, 3])
Tracked 3-element Vector{Float64}:
 1.0
 2.0
 3.0

julia> tb = 2*ta
[ Info: Chainrules for broadcasted(*, ...), specialized
Tracked 3-element Vector{Float64}:
 2.0
 4.0
 6.0

julia> print_graph(stdout, tb)
TrackedType
-data=[2.0, 4.0, 6.0]
-Tracker=
--pullback=#111
--grad=UndefInitializer()
--Parents=
---ConstantNode=Tracker.ConstantNode{Int64}(2)
---TrackedType
----data=[1.0, 2.0, 3.0]
----Tracker=
-----pullback=nothing
-----grad=[0.0, 0.0, 0.0]
-----Parents=()
```